### PR TITLE
improve udev rules to grant active users access

### DIFF
--- a/Linux_udevrules/70-stm32vcp.rules
+++ b/Linux_udevrules/70-stm32vcp.rules
@@ -1,0 +1,1 @@
+ATTRS{idVendor}=="0483", ATTRS{idProduct}=="5740", ENV{ID_MM_DEVICE_IGNORE}="1", TAG+="uaccess"

--- a/Linux_udevrules/90-stm32vcp.rules
+++ b/Linux_udevrules/90-stm32vcp.rules
@@ -1,1 +1,0 @@
-ATTRS{idVendor}=="0483", ATTRS{idProduct}=="5740", ENV{ID_MM_DEVICE_IGNORE}="1"

--- a/Linux_udevrules/README
+++ b/Linux_udevrules/README
@@ -2,10 +2,11 @@ Problems with Linux (Ubuntu and others):
 ========================================
 
 To reduce the initial delay after connecting USB you need to exclude the virtual com port from "modemmanager" to check it as a modem.
+Also you want to grant currently logged in users access to the tty device so you don't have to use sudo to flash a microcontroller.
 
-Copy the udev rule file "90-stm32vcp.rules" to "/etc/udev/rules.d" and reload udev manager with "udevadm control --reload"
+Copy the udev rule file "70-stm32vcp.rules" to "/etc/udev/rules.d" and reload udev manager with "udevadm control --reload"
 
 Or just use the following command:
 
-sudo bash -c 'cp 90-stm32vcp.rules /etc/udev/rules.d/ ; udevadm control --reload'
+sudo bash -c 'cp 70-stm32vcp.rules /etc/udev/rules.d/ ; udevadm control --reload'
 


### PR DESCRIPTION
Tag the device with "uaccess". On somewhat recent systems systemd-uaccess will
detect this and automatically grant active users access to the tty device.

Rename the udev file to 70-* because systemd's uacess-logic is done at 73-* and the
tag has to be set before that to be effective.