### PR TITLE
Still print the closest calibration value even if it isn't close enough

### DIFF
--- a/easypdkprog.c
+++ b/easypdkprog.c
@@ -546,6 +546,7 @@ int main( int argc, const char * argv [] )
                 //found valid tuning (max 10% drift) ?
                 if( abs( (int32_t)fcalfreq - (int32_t)calibdata[calib].frequency ) > (calibdata[calib].frequency/10) )
                 {
+                  printf("(0x%02X)  ", fcalval);
                   printf("out of range.\n");
                   fprintf(stderr, "ERROR: Calibration failed\n");
                   return -18;


### PR DESCRIPTION
I found this useful when trying to add support for PMS152 while troubleshooting why calibration wasn't working properly.

This branch/PR separates it out from the main PMS152 branch/PR since technically it is unrelated at this point.