### PR TITLE
Add support for mini-pill hardware variant

### DIFF
--- a/Firmware/source/Src/fpdk.c
+++ b/Firmware/source/Src/fpdk.c
@@ -491,7 +491,7 @@ void FPDK_Init(void)
 
   switch( hwdet )
   {
-    case 1: _hw_variant = FPDK_HWVAR_MINI_PILL; break;
+    case 2: _hw_variant = FPDK_HWVAR_MINI_PILL; break;
 
     default:
       _hw_variant = FPDK_HWVAR_NONE;


### PR DESCRIPTION
@freepdk - I was able to test the changes you made yesterday to add support for hardware variants.  Unfortunately, there was a bug in the 'id' that was used to identify the mini-pill variant.  This PR fixes that bug, and has been verified working using the easypdkprogtest utility.