### PR TITLE
Fix writing devices with 4KiB flash

### DIFF
--- a/fpdkcom.c
+++ b/fpdkcom.c
@@ -449,7 +449,7 @@ int FPDKCOM_IC_Write(const int fd,
                     write_block_clock_group_trail_clocks };
 
   uint8_t resp[3+sizeof(uint16_t)];
-  if( sizeof(resp) != _FPDKCOM_SendReceiveCommandWithTimeout(fd, FPDKPROTO_CMD_WRITEIC, dat,sizeof(dat), resp, sizeof(resp), FPDKCOM_CMDRSP_READIC_TIMEOUT) )
+  if( sizeof(resp) != _FPDKCOM_SendReceiveCommandWithTimeout(fd, FPDKPROTO_CMD_WRITEIC, dat,sizeof(dat), resp, sizeof(resp), FPDKCOM_CMDRSP_WRITE_TIMEOUT) )
     return -1;
 
   return( resp[3] | (((int)resp[4])<<8) );

--- a/fpdkcom.c
+++ b/fpdkcom.c
@@ -31,7 +31,7 @@ static const char FPDK_VERSCAN[] = "FREE-PDK EASY PROG - HW:%u.%u SW:%u.%u PROTO
 #define FPDKCOM_CMDRSP_PROBEIC_TIMEOUT      3500
 #define FPDKCOM_CMDRSP_READIC_TIMEOUT       1000
 #define FPDKCOM_CMDRSP_ERASE_TIMEOUT        2000
-#define FPDKCOM_CMDRSP_WRITE_TIMEOUT        2000
+#define FPDKCOM_CMDRSP_WRITE_TIMEOUT        4000
 #define FPDKCOM_CMDRSP_CALIBRATEIC_TIMEOUT  10000
 
 static bool _FPDKCOM_SendCommand(const int fd, const FPDKPROTO_CMD cmd, const uint8_t* dat, const uint8_t len)


### PR DESCRIPTION
`easypdkprog` previously used the read timeout for the write command, resulting in a timeout of only 1s instead of 2s. Also writing the full flash on a PFC161 (4KiB / 2Ki words) takes 2.8s, more than the previous write timeout.
Use the correct timeout and increase it to 4s so that we can write the full amount of flash on PFC161 with sufficient margin for production tolerances and wear.