### PR TITLE
Fixed command for installing linux udev rule

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -25,7 +25,7 @@ Problems with Linux distributions (Ubuntu and others):
 To reduce the initial delay after connecting USB you need to exclude the virtual com port from "modemmanager" to check it as a modem.
 You can do this by the following command:
 
-sudo bash -c 'cp udevrules/90-stm32vcp.rules /etc/udev/rules.d/ ; udevadm control --reload'
+sudo bash -c 'cp Linux_udevrules/70-stm32vcp.rules /etc/udev/rules.d/ ; udevadm control --reload'
 
 
 ************


### PR DESCRIPTION
The command in the INSTALL file to install the linux udev rules appears to have been outdated (the files names have changed)

Updated with the current file names.