### PR TITLE
Added .gitignore to ignore binary files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+easypdkprog
+*.o


### PR DESCRIPTION
The binary files keep showing up with `git status`, so I added them to the `.gitignore`. Seems like a useful thing to do.